### PR TITLE
chore: clean deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@types/jest": "^25.2.1",
-    "@types/lodash": "^4.14.150",
+    "@types/lodash.isequal": "^4.5.5",
     "@umijs/fabric": "^2.0.8",
     "eslint": "^6.8.0",
     "father": "^2.16.0",
@@ -37,7 +37,7 @@
   "license": "MIT",
   "dependencies": {
     "hash.js": "^1.1.7",
-    "lodash": "^4.17.15",
+    "lodash.isequal": "^4.5.0",
     "memoize-one": "^5.1.1",
     "path-to-regexp": "2.4.0"
   }

--- a/package.json
+++ b/package.json
@@ -30,15 +30,15 @@
     "@umijs/fabric": "^2.0.8",
     "eslint": "^6.8.0",
     "father": "^2.16.0",
-    "typescript": "^3.3.3"
+    "np": "^6.2.3",
+    "typescript": "^3.3.3",
+    "umi-test": "^1.9.6"
   },
   "license": "MIT",
   "dependencies": {
     "hash.js": "^1.1.7",
     "lodash": "^4.17.15",
     "memoize-one": "^5.1.1",
-    "np": "^6.2.3",
-    "path-to-regexp": "2.4.0",
-    "umi-test": "^1.9.6"
+    "path-to-regexp": "2.4.0"
   }
 }

--- a/src/transformRoute/transformRoute.ts
+++ b/src/transformRoute/transformRoute.ts
@@ -1,4 +1,4 @@
-import { isEqual } from 'lodash';
+import isEqual from 'lodash.isequal';
 import memoizeOne from 'memoize-one';
 import hash from 'hash.js';
 


### PR DESCRIPTION
安装 @ant-design/pro-layout 后发现 node_modules 有点膨胀。

其中一个原因是，pro-layout 使用到了这个库，而这里错误的在 dependencies 里声明了用户端不需要的包（`np` + `umi-test`）。

```sh
> npm init -y
> npm install @umijs/route-utils@latest
> du -sh node_modules

173M   node_modules
```