### PR TITLE
修复菜单项国际化

### DIFF
--- a/src/transformRoute/transformRoute.ts
+++ b/src/transformRoute/transformRoute.ts
@@ -56,10 +56,7 @@ const getItemLocaleName = (
   const { name, locale } = item;
 
   // 如果配置了 locale 并且 locale 为 false或 ""
-  if ('locale' in item && !locale) {
-    return '';
-  }
-  if (!name || locale === false) {
+  if (('locale' in item && locale === false) || !name) {
     return false;
   }
   return item.locale || `${parentName}.${name}`;


### PR DESCRIPTION
当某个菜单项的locale 为 false时，始终返回“” 作为国际化的key