### PR TITLE
fix: Solve the problem that when the parent menu has permission, the submenu does not have permission, and the submenu can be accessed through URL

### DIFF
--- a/src/getMatchMenu/getMatchMenu.ts
+++ b/src/getMatchMenu/getMatchMenu.ts
@@ -9,6 +9,7 @@ import {
 export const getMenuMatches = (
   flatMenuKeys: string[] = [],
   path: string,
+  exact?: boolean,
 ): string[] | undefined =>
   flatMenuKeys
     .filter((item) => {
@@ -22,8 +23,13 @@ export const getMenuMatches = (
           if (pathToRegexp(`${pathKey}`, []).test(path)) {
             return true;
           }
-          // /a/b/b
-          if (pathToRegexp(`${pathKey}/(.*)`).test(path)) {
+          // exact
+          if (exact) {
+            if (pathToRegexp(`${pathKey}`).test(path)) {
+              return true;
+            }
+            // /a/b/b
+          } else if (pathToRegexp(`${pathKey}/(.*)`).test(path)) {
             return true;
           }
         } catch (error) {
@@ -56,10 +62,11 @@ export const getMatchMenu = (
    * 要不要展示全部的 key
    */
   fullKeys?: boolean,
+  exact?: boolean,
 ): MenuDataItem[] => {
   const flatMenus = getFlatMenu(menuData);
   const flatMenuKeys = Object.keys(flatMenus);
-  let menuPathKeys = getMenuMatches(flatMenuKeys, pathname || '/');
+  let menuPathKeys = getMenuMatches(flatMenuKeys, pathname || '/', exact);
   if (!menuPathKeys || menuPathKeys.length < 1) {
     return [];
   }

--- a/src/getMatchMenu/getMatchMenu.ts
+++ b/src/getMatchMenu/getMatchMenu.ts
@@ -1,5 +1,5 @@
 import { pathToRegexp } from '@qixian.cs/path-to-regexp';
-import { MenuDataItem } from '../types';
+import type { MenuDataItem } from '../types';
 import getFlatMenu from '../getFlatMenus/getFlatMenus';
 import {
   isUrl,
@@ -19,17 +19,18 @@ export const getMenuMatches = (
       if (item !== '/' && item !== '/*' && item && !isUrl(item)) {
         const pathKey = stripQueryStringAndHashFromPath(item);
         try {
-          // /a
-          if (pathToRegexp(`${pathKey}`, []).test(path)) {
-            return true;
-          }
           // exact
           if (exact) {
             if (pathToRegexp(`${pathKey}`).test(path)) {
               return true;
             }
-            // /a/b/b
-          } else if (pathToRegexp(`${pathKey}/(.*)`).test(path)) {
+          }
+          // /a
+          if (pathToRegexp(`${pathKey}`, []).test(path)) {
+            return true;
+          }
+          // /a/b/b
+          if (pathToRegexp(`${pathKey}/(.*)`).test(path)) {
             return true;
           }
         } catch (error) {

--- a/src/sha265.tsx
+++ b/src/sha265.tsx
@@ -251,13 +251,13 @@ function sha256_update(data: string, inputLen: number) {
 
   /* Transform as many times as possible */
   for (i = 0; i + 63 < inputLen; i += 64) {
-    for (var j = index; j < 64; j++) buffer[j] = data.charCodeAt(curpos++);
+    for (let j = index; j < 64; j++) buffer[j] = data.charCodeAt(curpos++);
     sha256_transform();
     index = 0;
   }
 
   /* Buffer remaining input */
-  for (var j = 0; j < remainder; j++) buffer[j] = data.charCodeAt(curpos++);
+  for (let j = 0; j < remainder; j++) buffer[j] = data.charCodeAt(curpos++);
 }
 
 /* Finish the computation by operations such as padding */
@@ -265,11 +265,11 @@ function sha256_final() {
   let index = (count[0] >> 3) & 0x3f;
   buffer[index++] = 0x80;
   if (index <= 56) {
-    for (var i = index; i < 56; i++) buffer[i] = 0;
+    for (let i = index; i < 56; i++) buffer[i] = 0;
   } else {
-    for (var i = index; i < 64; i++) buffer[i] = 0;
+    for (let i = index; i < 64; i++) buffer[i] = 0;
     sha256_transform();
-    for (var i = 0; i < 56; i++) buffer[i] = 0;
+    for (let i = 0; i < 56; i++) buffer[i] = 0;
   }
   buffer[56] = (count[1] >>> 24) & 0xff;
   buffer[57] = (count[1] >>> 16) & 0xff;

--- a/test/__snapshots__/getMatchMenu.test.ts.snap
+++ b/test/__snapshots__/getMatchMenu.test.ts.snap
@@ -1,5 +1,96 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`exact 1`] = `
+Array [
+  Object {
+    "access": "canAdmin",
+    "children": Array [
+      Object {
+        "access": "canAdmin",
+        "children": Array [
+          Object {
+            "access": "canAdmin",
+            "children": undefined,
+            "exact": true,
+            "key": "/admin/sub-page/list",
+            "locale": "menu.admin.sub-page.sub-page-list",
+            "name": "三级管理页",
+            "path": "/admin/sub-page/list",
+            "pro_layout_parentKeys": Array [
+              "/admin",
+              "/admin/sub-page",
+            ],
+            "routes": null,
+            "unaccessible": false,
+          },
+        ],
+        "exact": true,
+        "key": "/admin/sub-page",
+        "locale": "menu.admin.sub-page",
+        "name": "二级管理页",
+        "path": "/admin/sub-page",
+        "pro_layout_parentKeys": Array [
+          "/admin",
+        ],
+        "routes": null,
+        "unaccessible": false,
+      },
+    ],
+    "key": "/admin",
+    "locale": "menu.admin",
+    "name": "管理页",
+    "path": "/admin",
+    "pro_layout_parentKeys": Array [],
+    "routes": null,
+  },
+  Object {
+    "access": "canAdmin",
+    "children": Array [
+      Object {
+        "access": "canAdmin",
+        "children": undefined,
+        "exact": true,
+        "key": "/admin/sub-page/list",
+        "locale": "menu.admin.sub-page.sub-page-list",
+        "name": "三级管理页",
+        "path": "/admin/sub-page/list",
+        "pro_layout_parentKeys": Array [
+          "/admin",
+          "/admin/sub-page",
+        ],
+        "routes": null,
+        "unaccessible": false,
+      },
+    ],
+    "exact": true,
+    "key": "/admin/sub-page",
+    "locale": "menu.admin.sub-page",
+    "name": "二级管理页",
+    "path": "/admin/sub-page",
+    "pro_layout_parentKeys": Array [
+      "/admin",
+    ],
+    "routes": null,
+    "unaccessible": false,
+  },
+  Object {
+    "access": "canAdmin",
+    "children": undefined,
+    "exact": true,
+    "key": "/admin/sub-page/list",
+    "locale": "menu.admin.sub-page.sub-page-list",
+    "name": "三级管理页",
+    "path": "/admin/sub-page/list",
+    "pro_layout_parentKeys": Array [
+      "/admin",
+      "/admin/sub-page",
+    ],
+    "routes": null,
+    "unaccessible": false,
+  },
+]
+`;
+
 exports[`normal 1`] = `
 Array [
   Object {

--- a/test/getMatchMenu.test.ts
+++ b/test/getMatchMenu.test.ts
@@ -155,7 +155,7 @@ const { menuData } = transformRoute(routes, true, ({ id }) => {
 });
 
 test('normal', () => {
-  const openMenuItems = getMatchMenu('/admin/sub-page', menuData, false, true);
+  const openMenuItems = getMatchMenu('/admin/sub-page', menuData);
   expect(openMenuItems.length).toEqual(2);
 
   expect(openMenuItems[0].name).toEqual('管理页');
@@ -174,7 +174,7 @@ test('three path', () => {
 });
 
 test('exact', () => {
-  const openMenuItems = getMatchMenu('/admin/sub-page/list', menuData);
+  const openMenuItems = getMatchMenu('/admin/sub-page/list', menuData, false, true);
   expect(openMenuItems.length).toEqual(3);
 
   expect(openMenuItems[0].name).toEqual('管理页');

--- a/test/getMatchMenu.test.ts
+++ b/test/getMatchMenu.test.ts
@@ -155,7 +155,7 @@ const { menuData } = transformRoute(routes, true, ({ id }) => {
 });
 
 test('normal', () => {
-  const openMenuItems = getMatchMenu('/admin/sub-page', menuData);
+  const openMenuItems = getMatchMenu('/admin/sub-page', menuData, false, true);
   expect(openMenuItems.length).toEqual(2);
 
   expect(openMenuItems[0].name).toEqual('管理页');
@@ -164,6 +164,16 @@ test('normal', () => {
 });
 
 test('three path', () => {
+  const openMenuItems = getMatchMenu('/admin/sub-page/list', menuData);
+  expect(openMenuItems.length).toEqual(3);
+
+  expect(openMenuItems[0].name).toEqual('管理页');
+  expect(openMenuItems[1].name).toEqual('二级管理页');
+  expect(openMenuItems[2].name).toEqual('三级管理页');
+  expect(openMenuItems).toMatchSnapshot();
+});
+
+test('exact', () => {
   const openMenuItems = getMatchMenu('/admin/sub-page/list', menuData);
   expect(openMenuItems.length).toEqual(3);
 


### PR DESCRIPTION
解决父菜单分配了权限，但是子菜单没分配权限，仍然可以通过url访问的问题
例如
`[{ path: '/order', authority: ['admin'], children: [{ path: '/order/detail' }] }]`
我在自己的项目中把getMenuMatches方法抽了出来，加了一个exact可选参数，解决了这个问题，作为扩展参数，不会影响之前的功能