### PR TITLE
转换route时候保留route的children属性，避免与react-route6的routeObject冲突

### DIFF
--- a/src/transformRoute/transformRoute.ts
+++ b/src/transformRoute/transformRoute.ts
@@ -190,7 +190,8 @@ function formatter(
         // eslint-disable-next-line no-param-reassign
         item.routes = item.children;
         // eslint-disable-next-line no-param-reassign
-        delete item.children;
+        // 支持react-router6的routeObject格式
+        // delete item.children;
       }
 
       const path = mergePath(item.path, parent ? parent.path : '/');


### PR DESCRIPTION
使用场景： react route6与 prolayout 结合使用。

react route6 的 routeObject格式
```
export interface RouteObject {
  caseSensitive?: boolean;
  children?: RouteObject[];
  element?: React.ReactNode;
  index?: boolean;
  path?: string;
}
```

prolayout 的menu格式是：
```
export interface MenuDataItem {
  /** @name 子菜单 */
  routes?: MenuDataItem[];
  /** @name 在菜单中隐藏子节点 */
  hideChildrenInMenu?: boolean;
  /** @name 在菜单中隐藏自己和子节点 */
  hideInMenu?: boolean;
  /** @name 在面包屑中隐藏 */
  hideInBreadcrumb?: boolean;
  /** @name 菜单的icon */
  icon?: React.ReactNode;
  /** @name 自定义菜单的国际化 key */
  locale?: string | false;
  /** @name 菜单的名字 */
  name?: string;
  /** @name 用于标定选中的值，默认是 path */
  key?: string;
  /** @name disable 菜单选项 */
  disabled?: boolean;
  /** @name 路径,可以设定为网页链接 */
  path?: string;
  /**
   * @deprecated 当此节点被选中的时候也会选中 parentKeys 的节点
   * @name 自定义父节点
   */
  parentKeys?: string[];
  /** @name 隐藏自己，并且将子节点提升到与自己平级 */
  flatMenu?: boolean;
  /** @name 指定外链打开形式，同a标签 */
  target?: string;

  [key: string]: any;
}
```
这导致在使用 react-router6 （使用children标识子路由）格式的object 喂给prolayout的menu时，transformRoute.jsx 把原 route.children 换成了route.routes。导致后续手工调用react-router6的matchpath匹配失败。示例代码如下：

  ```

const pickRoutes = memoized((routes, pathname) => {
  let matches = matchRoutes(routes, { pathname });
  const routeConfig = matches ? matches[matches.length - 1].route : null;
  return {
    routeConfig,
    // matchPath: matches ? matches.map(match => _.replace(match.route.path,'/*','')).join('/') : null // 解决下微端/*路径的问题
    matchPath: routeConfig ? _.replace(routeConfig.key, '/*', '') : null,
  };
});
const orgRoute = useRecoilValue(dynamicRouteAtom);  

  //手工转换下
  // transDynamicConfigAtom 貌似无法触发prolayout 的menu 更新，深表痛心。

  const route = useCreation(
    () => translateNameProperty(orgRoute, locale),
    [orgRoute, locale],
  );

  const { routeConfig, matchPath } = pickRoutes(orgRoute, location.pathname);

  return (
    <div id="prolayout" key="prolayout">
      <ProLayout
        style={{
          height: '100vh',
        }}
        menuDataRender={() => route}
        ...
       />
   </div>)
```

useCreation 底层是使用useRef。看起来条件不会重新计算，但是将route 喂给 prolayout后，原route.children就变成 route.routes的，导致 pickRoutes 调用匹配失败.. 结果导致useCreation 本意不重新计算返回原值，但实际被prolayout调用的route-utils 修改了原route数据了。
https://github.com/X-neuron/antdFront/issues/19
